### PR TITLE
Fix RIP card display after game over

### DIFF
--- a/VersionControl.md
+++ b/VersionControl.md
@@ -1,0 +1,6 @@
+# VersionControl
+
+## BugFixes
+- Verhindert, dass die RIP-Karte nach Spielende angezeigt wird,
+  indem die "playerEliminated"-Nachricht nur gesendet wird,
+  wenn das Spiel weitergeht.

--- a/server.js
+++ b/server.js
@@ -185,11 +185,12 @@ io.on("connection", (socket) => {
                             name: victim.name
                         });
 
-                        // Benachrichtigung an das Opfer senden
-                        io.to(victim.id).emit("playerEliminated", victim.id);
-
-                        // Spielstatus prüfen
-                        checkGameStatus(room);
+                        // Spielstatus prüfen – nur RIP senden, wenn das Spiel weitergeht
+                        const gameContinues = !checkGameStatus(room);
+                        if (gameContinues) {
+                            // Benachrichtigung an das Opfer senden
+                            io.to(victim.id).emit("playerEliminated", victim.id);
+                        }
                     }
                 }
             }
@@ -418,6 +419,11 @@ function endDayPhase(room) {
                     votes: maxVotes
                 });
 
+                // Spielstatus prüfen – RIP nur senden, wenn das Spiel weitergeht
+                if (checkGameStatus(room)) {
+                    return; // Spiel ist vorbei
+                }
+
                 // Benachrichtigung an das Opfer senden
                 io.to(victim.id).emit("playerEliminated", victim.id);
 
@@ -428,11 +434,6 @@ function endDayPhase(room) {
                     alive: p.alive,
                     role: p.role
                 })));
-
-                // Spielstatus prüfen
-                if (checkGameStatus(room)) {
-                    return; // Spiel ist vorbei
-                }
 
                 // Nach 5 Sekunden die nächste Nachtphase starten
                 setTimeout(() => startNightPhase(room), 5000);


### PR DESCRIPTION
## Summary
- Avoid sending `playerEliminated` when game end is triggered to prevent RIP card from showing after game over.
- Documented the fix in VersionControl.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689408b89d148327b5d413ff7f3ca265